### PR TITLE
fixed class { 'openjdk7::jre': } issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ See http://www.apache.org/licenses/LICENSE-2.0.html for the full license text.
 Support
 -------
 
-Please log tickets and issues at our [project site](https://github.com/smarchive/puppet-openjdk7/issues).
+Please log tickets and issues at our [project site](https://github.com/gini/puppet-openjdk7/issues).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The module has been tested on the following operating systems. Testing and patch
 
 * Fedora 17
 * Fedora 18
+* Ubuntu 12.04 LTS
 
 License
 -------

--- a/manifests/doc.pp
+++ b/manifests/doc.pp
@@ -18,6 +18,9 @@ class openjdk7::doc(
   $package = 'UNSET',
   $version = 'UNSET',
 ) {
+
+  if ($package == "UNSET" or $version == 'UNSET') { include openjdk7::params }
+
   $version_real = $version ? {
     'UNSET' => $::openjdk7::params::version,
     default => $version,

--- a/manifests/jdk.pp
+++ b/manifests/jdk.pp
@@ -18,6 +18,9 @@ class openjdk7::jdk(
   $package = 'UNSET',
   $version = 'UNSET',
 ) {
+
+  if ($package == "UNSET" or $version == 'UNSET') { include openjdk7::params }
+
   $version_real = $version ? {
     'UNSET' => $::openjdk7::params::version,
     default => $version,

--- a/manifests/jre.pp
+++ b/manifests/jre.pp
@@ -18,6 +18,9 @@ class openjdk7::jre(
   $package = 'UNSET',
   $version = 'UNSET',
 ) {
+
+  if ($package == "UNSET" or $version == 'UNSET') { include openjdk7::params }
+
   $version_real = $version ? {
     'UNSET' => $::openjdk7::params::version,
     default => $version,


### PR DESCRIPTION
it's now possible to just install e.g. the openjdk jre 

``` puppet
class { 'openjdk7::jre': }
```

and small update to readme file
